### PR TITLE
Camera abstraction

### DIFF
--- a/MAPLE.cfg
+++ b/MAPLE.cfg
@@ -21,3 +21,8 @@ Z2OffsetY = 7
 Z2OffsetZ = 10.7
 
 
+# To implement support for your own camera, follow examples in cameras.py.
+
+# Uncomment to use OpenCV supported camera.
+# camera_class = cameras.OpenCVCamera
+

--- a/cameras.py
+++ b/cameras.py
@@ -6,8 +6,8 @@
 """
 Abstraction layer for other camera interfaces (pyicic, opencv, etc)
 
-To implement a custom camera, subclass cameras.Camera, and implement the two
-methods with the @abstractmethod decorator (get_frame and close)
+To implement a custom camera, subclass cameras.Camera, and implement the
+methods with the @abstractmethod decorator.
 """
 
 import abc
@@ -32,6 +32,9 @@ class Camera(ABC):
         Camera needs an __init__ with no arguments, so it can be instantiated
         in a uniform way inside of the MAPLE __init__.
 
+        Any dependencies specific to your camera should be imported as the first
+        lines inside this function.
+
         Your __init__ implementation will likely create some other Python object
         to manage interactions with the camera through whatever other library.
         If this object is called `backing_camera_object`, the last line of your
@@ -49,7 +52,6 @@ class Camera(ABC):
         ```
         """
         pass
-
 
     @abstractmethod
     def get_frame(self):

--- a/cameras.py
+++ b/cameras.py
@@ -94,9 +94,6 @@ class Camera(ABC):
         IMWRITE_JPEG_QUALITY = 1
         cv2.imwrite(filename, frame, [IMWRITE_JPEG_QUALITY, quality])
 
-    # TODO context manager fns for starting resources / freeing them?
-    # TODO provide instance variable for backing camera object (as property?)
-
 
 class PyICIC_Camera(Camera):
     def __init__(self):

--- a/cameras.py
+++ b/cameras.py
@@ -1,0 +1,155 @@
+
+"""
+Abstraction layer for other camera interfaces (pyicic, opencv)
+"""
+
+import abc
+from abc import abstractmethod
+import warnings
+
+import numpy as np
+import cv2
+
+# TODO module (file) level list of supported cam properties?
+# then take dict of those @ constructors, via base class?
+
+class CameraNotFoundError(IOError): pass
+
+# Should work across Python 2 and 3.
+# see: https://gist.github.com/alanjcastonguay/25e4db0edd3534ab732d6ff615ca9fc1
+ABC = abc.ABCMeta('ABC', (object,), {})
+
+class Camera(ABC):
+    # TODO context manager fns for starting resources / freeing them? do any of
+    # those functions actually need to be called for the kind of operation we
+    # will use the cameras for?
+
+    # TODO type hint on return type + comment on dims, colorspace, etc
+    @abstractmethod
+    def get_frame(self):
+        pass
+
+    # TODO provide instance variable for backing camera object
+
+    def write_png(self, filename):
+        """
+        Args:
+            filename (str): Path to save to.
+        """
+        # TODO make sure this uses the subclass get_frame
+        frame = self.get_frame()
+        cv2.imwrite(filename, frame)
+
+
+    def write_jpg(self, filename, quality=50):
+        """
+        Args:
+            filename (str): Path to save to.
+            quality (int): (optional) 0-100 jpg quality (check bounds. 99?)
+        """
+        frame = self.get_frame()
+        raise NotImplementedError
+        # TODO add jpeg quality option
+        cv2.imwrite(filename, frame)
+
+
+class PyICIC_Camera(Camera):
+    def __init__(self):
+        import pyicic.IC_ImagingControl
+
+        ic_ic = pyicic.IC_ImagingControl.IC_ImagingControl()
+        ic_ic.init_library()
+        cam_names = ic_ic.get_unique_device_names()
+
+        if len(cam_names) == 0:
+            raise CameraNotFoundError
+
+        cam = ic_ic.get_device(cam_names[0])
+        cam.open()
+
+        cam.gain.value = 10
+        cam.exposure.auto = False
+        # TODO does a negative exposure make sense?
+        cam.exposure.value = -10
+        cam.set_video_format('BY8 (2592x1944)')
+        cam.set_frame_rate(4.00)
+
+        cam.prepare_live()
+
+        self.cam = cam
+
+
+    def get_frame(self):
+        """Returns a current frame from the camera.
+        """
+        # TODO TODO normalized format. numpy array? colorspace? how to check?
+        self.cam.start_live()
+        self.cam.snap_image()
+        imgdata, w, h, d = self.cam.get_image_data()
+        self.cam.stop_live()
+        return np.ndarray(buffer=imgdata, dtype=np.uint8, shape=(h, w, d))
+
+
+    def write_jpg(self, filename, quality=50):
+        """Writes a current image to filename in jpg format.
+        """
+        robot.cam.start_live()
+        robot.cam.snap_image()
+        # the 1 is for JPG, 0 is for BMP
+        robot.cam.save_image(filename, 1, jpeq_quality=qualPic)
+        robot.cam.stop_live()
+
+
+class OpenCVCamera(Camera):
+    def __init__(self):
+        if hasattr(cv2, 'cv'):
+            cv2_v3 = True
+        else:
+            cv2_v3 = False
+
+        def cap_prop_id(name):
+            """Returns cv2 integer code for property with name."""
+            # TODO also handle case where property doesn't exist
+            return getattr(cv2 if cv2_v3 else cv2.cv,
+                ('' if cv2_v3 else 'CV_') + 'CAP_PROP_' + name)
+
+        def set_property(vc, name, value):
+            """Sets cv2.VideoCapture property. Warns if can not."""
+            property_code = cap_prop_id(name)
+            v = vc.get(property_code)
+            if v == -1:
+                warnings.warn('Could not set property {}'.format(name))
+            else:
+                vc.set(property_code, value)
+
+        cam = VideoCapture(0)
+        if not cam.isOpened():
+            return None
+
+        # these don't need to happen before resource is open, do they?
+        set_property(cam, 'GAIN', 10)
+        # TODO false? 0?
+        # seems 0.25 might actually be value to turn off auto exposure?
+        # https://github.com/opencv/opencv/issues/9738
+        set_property(cam, 'AUTO_EXPOSURE', 0)
+        set_property(cam, 'EXPOSURE', -10)
+        # TODO this closest to by8 above? necessary?
+        #set_property(cam, 'FORMAT', )
+        # ?
+        #set_property(cam, 'FRAME_WIDTH', )
+        #set_property(cam, 'FRAME_HEIGHT', )
+        set_property(cam, 'FPS', 4.00)
+
+        # TODO provide unified camera cleanup call
+        # and put cam.release() there in this case
+
+        self.cam = cam
+
+
+    def get_frame():
+        """Returns a current frame from the camera.
+        """
+        # TODO TODO normalized format. numpy array? colorspace? how to check?
+        return self.cam.read()
+        #return np.ndarray(buffer=imgdata, dtype=np.uint8, shape=(h, w, d))
+

--- a/remoteOperation.py
+++ b/remoteOperation.py
@@ -41,7 +41,7 @@ def notifyUserFail(robot, arenanum, mailfrom, attPic=0, qualPic=25, attImg=1, de
         msg = MIMEMultipart()
         for imgnum in range(len(arenanum)):
             curarenanum = str(arenanum[imgnum])
-            imgname = curarenanum + 'errImage.png'
+            imgname = curarenanum + 'errImage.jpg'
             with open(imgname, 'rb') as fp:
                 img = MIMEImage(fp.read())
             msg.attach(img)
@@ -57,19 +57,19 @@ def notifyUserFail(robot, arenanum, mailfrom, attPic=0, qualPic=25, attImg=1, de
         time.sleep(0.2)
         robot.cam.start_live()
         robot.cam.snap_image()
-        robot.cam.save_image(arenanum + 'errImage.png', 1, jpeq_quality=qualPic)
+        robot.cam.save_image(arenanum + 'errImage.jpg', 1, jpeq_quality=qualPic)
         robot.cam.stop_live()
         robot.dwell(50)
         robot.light(False)
         msg['Subject'] = 'Failure: Arena ' + arenanum + ' Withdraw'
         msg = MIMEMultipart()
         msg.preamble = 'Arena ' + arenanum + ' failed to unload.'
-        fp = open(arenanum + 'errImage.png', 'rb')
+        fp = open(arenanum + 'errImage.jpg', 'rb')
         img = MIMEImage(fp.read())
         fp.close()
         msg.attach(img)
         if delFiles == 1:
-            os.remove(arenanum + 'errImage.png')
+            os.remove(arenanum + 'errImage.jpg')
     if attPic == 0 and attImg == 0:
         arenanum = str(arenanum)
         msg['Subject'] = 'Failure: Arena ' + arenanum + ' Withdraw'

--- a/remoteOperation.py
+++ b/remoteOperation.py
@@ -55,10 +55,7 @@ def notifyUserFail(robot, arenanum, mailfrom, attPic=0, qualPic=25, attImg=1, de
         arenanum = str(arenanum)
         robot.light(True)
         time.sleep(0.2)
-        robot.cam.start_live()
-        robot.cam.snap_image()
-        robot.cam.save_image(arenanum + 'errImage.jpg', 1, jpeq_quality=qualPic)
-        robot.cam.stop_live()
+        robot.write_jpg(arenanum + 'errImage.jpg', 1, quality=qualPic)
         robot.dwell(50)
         robot.light(False)
         msg['Subject'] = 'Failure: Arena ' + arenanum + ' Withdraw'

--- a/robotutil.py
+++ b/robotutil.py
@@ -86,10 +86,8 @@ class MAPLE:
             tempPort.close()
 
         if self.smoothie is None:
-            print "Serial initialization failed."
-            if self.smoothie is None:
-                print "Smoothie board not found."
-            return
+            raise IOError(
+                "Serial initialization failed. Smoothie board not found.")
 
         print "Initializing camera...",
         if cam_class is None:
@@ -118,7 +116,7 @@ class MAPLE:
         if self.cam == None:
             print "Camera init fail."
             self.smoothie.close()
-            return
+            raise IOError("Camera init fail.")
 
         print "done."
 

--- a/robotutil.py
+++ b/robotutil.py
@@ -11,14 +11,16 @@
 ## Dependencies
 import os
 import math
-import cv2
-import numpy as np
 import time
 import ConfigParser
 import urllib2
-import random as rand
-import pyicic.IC_ImagingControl
+import importlib
+
+import numpy as np
+import cv2
+
 import flysorterSerial
+import cameras
 
 class MAPLE:
     """Class for fly manipulation robot."""
@@ -57,10 +59,11 @@ class MAPLE:
                       'Z2OffsetZ': '8',
                       'HFOV': '14.5',
                       'VFOV': '11.25',
-                      'StatusURL': ''
+                      'StatusURL': '',
+                      'camera_class': 'cameras.PyICIC_Camera'
                       }
 
-    def __init__(self, robotConfigFile,initDisp=1):
+    def __init__(self, robotConfigFile, cam_class=None):
         print "Reading config file...",
         self.config = ConfigParser.RawConfigParser(self.configDefaults)
         self.readConfig(robotConfigFile)
@@ -89,7 +92,29 @@ class MAPLE:
             return
 
         print "Initializing camera...",
-        self.cam = cameraInit()
+        if cam_class is None:
+            parts = self.full_cam_class_name.rsplit('.', 1)
+            try:
+                cam_module = importlib.import_module(parts[0])
+            except ImportError as e:
+                # TODO maybe print this if there are any problems starting cam?
+                import pyclbr
+                cams = pyclbr.readmodule('cameras')
+                print(cams)
+                cams.remove('Camera')
+                print "Available cameras:"
+                for c in cams:
+                    print c
+                print "Set camera_class to one of them in your MAPLE.cfg file."
+                raise
+
+            cam_class = getattr(cam_module, parts[1])
+
+        if not issubclass(cam_class, cameras.Camera):
+            raise ValueError('Camera class must subclass cameras.Camera')
+
+        self.cam = cam_class()
+
         if self.cam == None:
             print "Camera init fail."
             self.smoothie.close()
@@ -119,7 +144,9 @@ class MAPLE:
         self.StatusURL = self.config.get('DEFAULT', 'StatusURL')
         if ( self.StatusURL != ''):
             urllib2.urlopen(StatusURL + "&" + "st=1")
-        return
+
+        self.full_cam_class_name = self.config.get('DEFAULT', 'camera_class')
+
 
     def release(self):
         self.light(False)
@@ -651,20 +678,3 @@ class MAPLE:
             tempdeg = self.getDegs(circles)
             return tempdeg
 
-
-# Set up close-up camera
-def cameraInit():
-    global ic_ic
-    print "Opening camera interface."
-    ic_ic = pyicic.IC_ImagingControl.IC_ImagingControl()
-    ic_ic.init_library()
-    cam_names = ic_ic.get_unique_device_names()
-    cam = ic_ic.get_device(cam_names[0])
-    cam.open()
-    cam.gain.value = 10
-    cam.exposure.auto = False
-    cam.exposure.value = -10
-    cam.set_video_format('BY8 (2592x1944)')
-    cam.set_frame_rate(4.00)
-    cam.prepare_live()
-    return cam

--- a/robotutil.py
+++ b/robotutil.py
@@ -463,7 +463,7 @@ class MAPLE:
         return
 
     # Captures arena picture at location (Images named consecutively if multiple coordinates specified)
-    def SavePicAt(self, Xcoords, Ycoords, IndVect, qualPic=25, Zcam=40, ImgName='errImage.png'):
+    def SavePicAt(self, Xcoords, Ycoords, IndVect, qualPic=25, Zcam=40, ImgName='errImage.jpg'):
         self.light(True)
         self.cam.start_live()
         for ImgNum in range(len(Xcoords)):
@@ -471,7 +471,7 @@ class MAPLE:
             self.dwell(50)      # Put higher to reduce effect of motion-caused rig trembling on picture
             self.cam.snap_image()
             curInd = str(IndVect[ImgNum])
-            self.cam.save_image(curInd + 'errImage.png', 1, jpeq_quality=qualPic)
+            self.cam.save_image(curInd + 'errImage.jpg', 1, jpeq_quality=qualPic)
             self.dwell(10)
         self.cam.stop_live()
         self.light(False)


### PR DESCRIPTION
### Interface
This breaks out camera handling to `cameras.py`, with each camera implementing an interface specified by the abstract class `cameras.Camera`.  Each camera must implement:

- `get_frame()`, which must return a `numpy.ndarray` frame of (h x w x color), in BGR colorspace
- `close()`
- `__init__()` (with no arguments beyond `self`, so it can be called in MAPLE constructor)

The superclass provides each subclass with a `write_jpg(filename, quality=95)` and `write_png(filename)` method for free, which uses OpenCV calls by default.  This can be overwritten with calls to the camera library for optimization, as I have done with the pyicic camera.

### Configuring
Cameras to use can be specified by giving a fully qualified (dot separated module + class) name as the value to the `camera_class` key, in the `MAPLE.cfg` file, so that the end user won't really have to change the code to specify the camera.  I've added some commented lines to `MAPLE.cfg` to show how you could change the camera to the OpenCV camera.

I also added a keyword argument to the MAPLE constructor to pass in a Python class directly, which should also be something subclassing the `cameras.Camera` interface class.  This uses less magic than the first approach, so it can serve as a kind of backup, and some people may wish to specify the camera in the same code that invokes the MAPLE constructor.

Using your dictionary of default values for the MAPLE class, I've kept the same default behavior (with no change to MAPLE.cfg), which is to use the pyicic camera.

### Possible problems
In one case, you guys had previously kept the pyicic camera live for a period while taking many frames.  As it is written, the cameras are mostly stateless, so if starting and stopping the live mode of the pyicic camera causes too much of a performance hit, I might need to provide some way to optionally keep cameras ready for acquisition.  Another possible solution to the above is to just put a call to `start_live` in `__init__` and a call to `stop_live` in `close`.

I don't have any cameras compatible with the `pyicic` library, so it would probably be good to test this code with your camera, to make sure I didn't break anything.

### Other minor changes
There were some calls to the pyicic `save_image` with a`.png` extension, that seemed to be actually saving `JPEG` formatted data, according to the documentation, so I changed the extension of those files to `.jpg` to reflect what seemed to be the output format.  You might prefer to use the `write_png` function instead, if you want to keep the same filename format.

Closes #14